### PR TITLE
Add consistency check and compilation for Kotlin CI scripts

### DIFF
--- a/.github/workflows/build.main.kts
+++ b/.github/workflows/build.main.kts
@@ -29,4 +29,47 @@ workflow(
         uses(action = ActionsSetupGradle())
         run(command = "./gradlew build")
     }
+
+    job(
+        id = "build_kotlin_scripts",
+        name = "Build Kotlin scripts",
+        runsOn = RunnerType.UbuntuLatest,
+    ) {
+        uses(action = Checkout())
+        run(
+            command = """
+            find -name *.main.kts -print0 | while read -d ${'$'}'\0' file
+            do
+                echo "Compiling ${'$'}file..."
+                kotlinc -Werror -Xallow-any-scripts-in-source-roots -Xuse-fir-lt=false "${'$'}file"
+            done
+            """.trimIndent()
+        )
+    }
+
+
+    job(
+        id = "workflows_consistency_check",
+        name = "Run consistency check on all GitHub workflows",
+        runsOn = RunnerType.UbuntuLatest,
+    ) {
+        uses(action = Checkout())
+        run(command = "cd .github/workflows")
+        run(
+            name = "Regenerate all workflow YAMLs",
+            command = """
+            find -name "*.main.kts" -print0 | while read -d ${'$'}'\0' file
+            do
+                if [ -x "${'$'}file" ]; then
+                    echo "Regenerating ${'$'}file..."
+                    (${'$'}file)
+                fi
+            done
+            """.trimIndent(),
+        )
+        run(
+            name = "Check if some file is different after regeneration",
+            command = "git diff --exit-code .",
+        )
+    }
 }

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,3 +33,41 @@ jobs:
       uses: 'gradle/actions/setup-gradle@v3'
     - id: 'step-2'
       run: './gradlew build'
+  build_kotlin_scripts:
+    name: 'Build Kotlin scripts'
+    runs-on: 'ubuntu-latest'
+    needs:
+    - 'check_yaml_consistency'
+    steps:
+    - id: 'step-0'
+      uses: 'actions/checkout@v4'
+    - id: 'step-1'
+      run: |-
+        find -name *.main.kts -print0 | while read -d $'\0' file
+        do
+            echo "Compiling $file..."
+            kotlinc -Werror -Xallow-any-scripts-in-source-roots -Xuse-fir-lt=false "$file"
+        done
+  workflows_consistency_check:
+    name: 'Run consistency check on all GitHub workflows'
+    runs-on: 'ubuntu-latest'
+    needs:
+    - 'check_yaml_consistency'
+    steps:
+    - id: 'step-0'
+      uses: 'actions/checkout@v4'
+    - id: 'step-1'
+      run: 'cd .github/workflows'
+    - id: 'step-2'
+      name: 'Regenerate all workflow YAMLs'
+      run: |-
+        find -name "*.main.kts" -print0 | while read -d $'\0' file
+        do
+            if [ -x "$file" ]; then
+                echo "Regenerating $file..."
+                ($file)
+            fi
+        done
+    - id: 'step-3'
+      name: 'Check if some file is different after regeneration'
+      run: 'git diff --exit-code .'


### PR DESCRIPTION
So that certain regressions in workflows that don't run for each PR are caught in PRs.