### PR TITLE
Remove wasm experimental Gradle repo

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,7 +25,6 @@ dependencyResolutionManagement {
             }
         }
         mavenCentral()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/wasm/experimental")
     }
 }
 


### PR DESCRIPTION
I think it's not needed anymore, and it includes some broken versions of ktor which confuses Renovate, see https://github.com/typesafegithub/github-actions-typing-editor/pull/35